### PR TITLE
Task and queue fixes

### DIFF
--- a/apps/api/src/endpoints/verifier/verifier.controller.ts
+++ b/apps/api/src/endpoints/verifier/verifier.controller.ts
@@ -1,6 +1,7 @@
 import {
   ContractVerifier,
   ParseScAddressPipe,
+  TaskIdResponse,
   Verifier,
   VerifierCodeHashResponse,
   VerifierDeletion,
@@ -19,7 +20,12 @@ export class VerifierController {
   ) {}
 
   @Post()
-  async verify(@Body() validateBody: Verifier): Promise<{taskId: string}> {
+  @ApiResponse({
+    status: 200,
+    description: 'Queues a contract verification task and returns the task ID',
+    type: TaskIdResponse,
+  })
+  async verify(@Body() validateBody: Verifier): Promise<TaskIdResponse> {
     return await this.taskService.runVerifier(validateBody);
   }
 

--- a/apps/queue-worker/src/app.module.ts
+++ b/apps/queue-worker/src/app.module.ts
@@ -1,12 +1,16 @@
-import { ApiMetricsController, ApiMetricsModule, CommonConfigModule, HealthCheckController } from '@libs/common';
+import {
+  ApiMetricsController,
+  ApiMetricsModule,
+  CommonConfigModule,
+  HealthCheckController,
+  PubSubListenerModule,
+} from '@libs/common';
 import { ServicesModule } from '@libs/services';
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
-import { BullModule } from '@nestjs/bull';
 import { Module } from '@nestjs/common';
 import { AppConfigModule } from './config/app-config.module';
 import { BullQueueModule } from './worker/bull.queue.module';
 import { VerifierQueueService } from './worker/queues/verifier.queue.service';
-import { WorkerService } from './worker/worker.service';
 
 @Module({
   imports: [
@@ -16,18 +20,14 @@ import { WorkerService } from './worker/worker.service';
     CommonConfigModule,
     BullQueueModule,
     ServicesModule,
-    BullModule.registerQueue({
-      name: 'verifierQueue',
-    }),
+    PubSubListenerModule.forRoot({ enableConsumer: true }),
   ],
   providers: [
-    WorkerService,
     VerifierQueueService,
   ],
   controllers: [
     ApiMetricsController,
     HealthCheckController,
   ],
-  exports: [WorkerService],
 })
 export class AppModule { }

--- a/apps/queue-worker/src/main.ts
+++ b/apps/queue-worker/src/main.ts
@@ -23,7 +23,7 @@ async function bootstrap() {
   await app.listen(appConfigService.config.port);
 
   const pubSubApp = await NestFactory.createMicroservice<MicroserviceOptions>(
-    PubSubListenerModule.forRoot({enableConsumer: true}),
+    PubSubListenerModule.forRoot({ enableConsumer: true }),
     {
       transport: Transport.REDIS,
       options: {

--- a/apps/queue-worker/src/main.ts
+++ b/apps/queue-worker/src/main.ts
@@ -7,12 +7,12 @@ dotenv.config({
   path: resolve(process.cwd(), envPath),
 });
 
-import 'module-alias/register';
-import { NestFactory } from '@nestjs/core';
 import { CommonConfigService, PubSubListenerModule } from '@libs/common';
-import { AppModule } from './app.module';
+import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import 'module-alias/register';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { AppModule } from './app.module';
 import { AppConfigService } from './config/app-config.service';
 
 async function bootstrap() {
@@ -23,7 +23,7 @@ async function bootstrap() {
   await app.listen(appConfigService.config.port);
 
   const pubSubApp = await NestFactory.createMicroservice<MicroserviceOptions>(
-    PubSubListenerModule.forRoot(),
+    PubSubListenerModule.forRoot({enableConsumer: true}),
     {
       transport: Transport.REDIS,
       options: {

--- a/apps/queue-worker/src/worker/queues/verifier.queue.service.ts
+++ b/apps/queue-worker/src/worker/queues/verifier.queue.service.ts
@@ -15,9 +15,9 @@ export class VerifierQueueService {
   }
 
   @Process({ name: 'validate', concurrency: 1 })
-  onVerifyRequest(job: Job<any>) {
+  async onVerifyRequest(job: Job<any>) {
     this.logger.log({ type: 'consumer', jobId: job.id, identifier: job.data.data.validate.payload.contract, attemptsMade: job.attemptsMade });
-    return this.worker.workVerifier(job.data.taskId, job.data.data.validate);
+    return await this.worker.workVerifier(job.data.taskId, job.data.data.validate);
   }
 
   @OnQueueError()

--- a/libs/common/src/dtos/task.ts
+++ b/libs/common/src/dtos/task.ts
@@ -8,3 +8,7 @@ export class Task {
   finished?: Date;
   result?: SuccessfulVerifierResponse | ErrorVerifierResponse;
 }
+
+export class TaskIdResponse {
+  taskId!: string;
+}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -6,4 +6,5 @@ export * from './health-check';
 export * from './metrics';
 export * from './pipes';
 export * from './pubsub';
+export * from './queue-worker';
 export * from './utils';

--- a/libs/common/src/pubsub/pub.sub.listener.controller.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Logger } from "@nestjs/common";
 import { EventPattern } from "@nestjs/microservices";
-import { WorkerService } from "apps/queue-worker/src/worker/worker.service";
+import { WorkerService } from "../queue-worker";
 
 @Controller()
 export class PubSubListenerController {

--- a/libs/common/src/pubsub/pub.sub.listener.module.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.module.ts
@@ -1,24 +1,31 @@
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { DynamicModule, Module } from '@nestjs/common';
-import { AppModule } from 'apps/queue-worker/src/app.module';
 import { CommonConfigModule } from '../config';
+import { QueueWorkerModule } from '../queue-worker/queue.worker.module';
 import { DynamicModuleUtils } from '../utils';
 import { PubSubListenerController } from './pub.sub.listener.controller';
 
+export interface PubSubListenerModuleOptions {
+  enableConsumer?: boolean;
+}
+
 @Module({})
 export class PubSubListenerModule {
-  static forRoot(): DynamicModule {
+  static forRoot(options: PubSubListenerModuleOptions = {}): DynamicModule {
+    // Only register controller if enableConsumer is true
+    const controllers = options.enableConsumer
+      ? [PubSubListenerController]
+      : [];
+
     return {
       module: PubSubListenerModule,
       imports: [
         LoggingModule,
         CommonConfigModule,
         DynamicModuleUtils.getCachingModule(),
-        AppModule,
+        QueueWorkerModule,
       ],
-      controllers: [
-        PubSubListenerController,
-      ],
+      controllers,
       providers: [
         DynamicModuleUtils.getPubSubService(),
       ],

--- a/libs/common/src/pubsub/pub.sub.listener.module.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.module.ts
@@ -1,7 +1,7 @@
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { DynamicModule, Module } from '@nestjs/common';
 import { CommonConfigModule } from '../config';
-import { QueueWorkerModule } from '../queue-worker/queue.worker.module';
+import { QueueWorkerModule } from '../queue-worker';
 import { DynamicModuleUtils } from '../utils';
 import { PubSubListenerController } from './pub.sub.listener.controller';
 

--- a/libs/common/src/queue-worker/index.ts
+++ b/libs/common/src/queue-worker/index.ts
@@ -1,0 +1,1 @@
+export * from './worker.service';

--- a/libs/common/src/queue-worker/index.ts
+++ b/libs/common/src/queue-worker/index.ts
@@ -1,1 +1,2 @@
+export * from './queue.worker.module';
 export * from './worker.service';

--- a/libs/common/src/queue-worker/queue.worker.module.ts
+++ b/libs/common/src/queue-worker/queue.worker.module.ts
@@ -1,0 +1,14 @@
+import { BullModule } from '@nestjs/bull';
+import { Module } from '@nestjs/common';
+import { WorkerService } from './worker.service';
+
+@Module({
+  imports: [
+    BullModule.registerQueue({
+      name: 'verifierQueue',
+    }),
+  ],
+  providers: [WorkerService],
+  exports: [WorkerService, BullModule],
+})
+export class QueueWorkerModule {}

--- a/libs/common/src/queue-worker/worker.service.ts
+++ b/libs/common/src/queue-worker/worker.service.ts
@@ -1,7 +1,7 @@
-import { Verifier } from "@libs/common";
 import { InjectQueue } from "@nestjs/bull";
 import { Injectable, Logger } from "@nestjs/common";
 import { Queue } from "bull";
+import { Verifier } from "../dtos";
 
 @Injectable()
 export class WorkerService {

--- a/libs/services/src/docker/docker.runner.ts
+++ b/libs/services/src/docker/docker.runner.ts
@@ -7,10 +7,6 @@ export class DockerRunner {
   private logger = new Logger('Docker');
 
   public exec(options: DockerRunnerOptionsInterface): Promise<string> {
-    this.logger.log(
-      `Started docker process with options: ${JSON.stringify(options)}`,
-    );
-
     const mountArgs = [];
 
     if (options.inputVolumeMap) {

--- a/libs/services/src/task/task.service.ts
+++ b/libs/services/src/task/task.service.ts
@@ -1,6 +1,7 @@
 import {
   CommonConfigService,
   Task,
+  TaskIdResponse,
   TaskStatus,
   Verifier,
 } from '@libs/common';
@@ -12,16 +13,15 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
-  Logger,
-  RequestTimeoutException,
+  Logger
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import { randomUUID } from 'crypto';
 
 @Injectable()
 export class TaskService {
-  private MAX_NUMBER_OF_ITERATIONS = 10;
-  private POLLING_INTERVAL = 500;
+  // private MAX_NUMBER_OF_ITERATIONS = 10;
+  // private POLLING_INTERVAL = 500;
   private readonly logger: Logger;
 
   constructor(
@@ -37,7 +37,7 @@ export class TaskService {
     return await this.cachingService.getRemote<Task>(`task:${id}`);
   }
 
-  async runVerifier(validate: Verifier): Promise<{ taskId: string }> {
+  async runVerifier(validate: Verifier): Promise<TaskIdResponse> {
     this.logger.log(
       `Received verifier request for contract ${validate.payload.contract}`,
     );
@@ -62,33 +62,34 @@ export class TaskService {
 
   private async run(type: string, value: any): Promise<any> {
     const taskId = await this.runWork(type, value);
+    return { taskId };
 
-    let iterations = 0;
+    // let iterations = 0;
 
-    return new Promise((resolve, reject) => {
-      const interval = setInterval(async () => {
-        iterations++;
-        const task = await this.cachingService.getRemote<Task>(
-          `task:${taskId}`,
-        );
-        if (task) {
-          if (task.status === TaskStatus.finished) {
-            clearInterval(interval);
-            resolve(task.result);
-          } else if (task.status === TaskStatus.error) {
-            clearInterval(interval);
-            if (task.result instanceof Array) {
-              reject(new BadRequestException({ errors: task.result }));
-            } else {
-              reject(new BadRequestException());
-            }
-          } else if (iterations >= this.MAX_NUMBER_OF_ITERATIONS) {
-            clearInterval(interval);
-            reject(new RequestTimeoutException({ taskId }));
-          }
-        }
-      }, this.POLLING_INTERVAL);
-    });
+    // return new Promise((resolve, reject) => {
+    //   const interval = setInterval(async () => {
+    //     iterations++;
+    //     const task = await this.cachingService.getRemote<Task>(
+    //       `task:${taskId}`,
+    //     );
+    //     if (task) {
+    //       if (task.status === TaskStatus.finished) {
+    //         clearInterval(interval);
+    //         resolve(task.result);
+    //       } else if (task.status === TaskStatus.error) {
+    //         clearInterval(interval);
+    //         if (task.result instanceof Array) {
+    //           reject(new BadRequestException({ errors: task.result }));
+    //         } else {
+    //           reject(new BadRequestException());
+    //         }
+    //       } else if (iterations >= this.MAX_NUMBER_OF_ITERATIONS) {
+    //         clearInterval(interval);
+    //         reject(new RequestTimeoutException({ taskId }));
+    //       }
+    //     }
+    //   }, this.POLLING_INTERVAL);
+    // });
   }
 
   private async runWork(type: string, value: any): Promise<string> {

--- a/libs/services/src/task/task.service.ts
+++ b/libs/services/src/task/task.service.ts
@@ -13,15 +13,13 @@ import {
   Inject,
   Injectable,
   InternalServerErrorException,
-  Logger
+  Logger,
 } from '@nestjs/common';
 import { ClientProxy } from '@nestjs/microservices';
 import { randomUUID } from 'crypto';
 
 @Injectable()
 export class TaskService {
-  // private MAX_NUMBER_OF_ITERATIONS = 10;
-  // private POLLING_INTERVAL = 500;
   private readonly logger: Logger;
 
   constructor(
@@ -63,33 +61,6 @@ export class TaskService {
   private async run(type: string, value: any): Promise<any> {
     const taskId = await this.runWork(type, value);
     return { taskId };
-
-    // let iterations = 0;
-
-    // return new Promise((resolve, reject) => {
-    //   const interval = setInterval(async () => {
-    //     iterations++;
-    //     const task = await this.cachingService.getRemote<Task>(
-    //       `task:${taskId}`,
-    //     );
-    //     if (task) {
-    //       if (task.status === TaskStatus.finished) {
-    //         clearInterval(interval);
-    //         resolve(task.result);
-    //       } else if (task.status === TaskStatus.error) {
-    //         clearInterval(interval);
-    //         if (task.result instanceof Array) {
-    //           reject(new BadRequestException({ errors: task.result }));
-    //         } else {
-    //           reject(new BadRequestException());
-    //         }
-    //       } else if (iterations >= this.MAX_NUMBER_OF_ITERATIONS) {
-    //         clearInterval(interval);
-    //         reject(new RequestTimeoutException({ taskId }));
-    //       }
-    //     }
-    //   }, this.POLLING_INTERVAL);
-    // });
   }
 
   private async runWork(type: string, value: any): Promise<string> {

--- a/libs/services/src/worker/worker.service.ts
+++ b/libs/services/src/worker/worker.service.ts
@@ -6,46 +6,43 @@ import {
 } from '@libs/common';
 import {
   Injectable,
+  Logger,
 } from '@nestjs/common';
-import AsyncLock from "async-lock";
 import { VerifierService } from '../verifier';
 import { WorkerCallbackService } from './worker.callback.service';
 
 @Injectable()
 export class WorkerService {
-  private readonly lock: AsyncLock;
+  private readonly logger: Logger = new Logger(WorkerService.name);
 
   constructor(
     private readonly verifierService: VerifierService,
     private readonly workerCallbackService: WorkerCallbackService,
   ) {
-    this.lock = new AsyncLock();
   }
 
   async workVerifier(taskId: string, validate: Verifier): Promise<void> {
+    this.logger.log(`Task ${taskId} - Starting work`);
+
     try {
-      await this.work(taskId, async () => await this.verifierService.validate(validate));
+      await this.updateTask(taskId, TaskStatus.started);
+
+      const workResult = await this.verifierService.validate(validate);
+
+      await this.updateTask(taskId, TaskStatus.finished, workResult);
+      this.logger.log(`Task ${taskId} - Work completed successfully`);
     } catch (error: any) {
+      this.logger.error(`Task ${taskId} failed`);
+
+      const errorResponse = {
+        message: error.response?.message || error.message || 'An error occurred',
+        error: error.response?.error || 'Error',
+        statusCode: error.response?.statusCode || 500,
+      };
+
+      await this.updateTask(taskId, TaskStatus.error, errorResponse);
       console.error(`Error in workVerifier for task ${taskId}; error: ${error.message}, stack: ${error.stack}`);
     }
-  }
-
-  private async work(taskId: string, promise: () => Promise<SuccessfulVerifierResponse>): Promise<SuccessfulVerifierResponse> {
-    await this.updateTask(taskId, TaskStatus.queued);
-
-    return await this.lock.acquire('task', async done => {
-      try {
-        await this.updateTask(taskId, TaskStatus.started);
-
-        const result = await promise();
-
-        await this.updateTask(taskId, TaskStatus.finished, result);
-        done(undefined, result);
-      } catch (error: any) {
-        await this.updateTask(taskId, TaskStatus.error, error.response);
-        done(error);
-      }
-    });
   }
 
   private async updateTask(

--- a/libs/services/src/worker/worker.service.ts
+++ b/libs/services/src/worker/worker.service.ts
@@ -41,7 +41,7 @@ export class WorkerService {
       };
 
       await this.updateTask(taskId, TaskStatus.error, errorResponse);
-      console.error(`Error in workVerifier for task ${taskId}; error: ${error.message}, stack: ${error.stack}`);
+      this.logger.error(`Error in workVerifier for task ${taskId}; error: ${error.message}, stack: ${error.stack}`);
     }
   }
 


### PR DESCRIPTION
## Type

- [ ] Bug
- [ ] Feature
- [x] Refactoring
- [ ] Performance improvement

## Problem setting

Previously, because of the architecture and because of how things are imported, jobs were processed in parallel. We want jobs to be processed sequentially. 

## Proposed Changes

Fixed jobs to run sequentially. Also, now, when requesting validation for a contract, the `taskId` is returned directly. There is no point in waiting 5s to throw a TimeoutError because no docker job (contract build) can be executed in such a short amount of time. The polling for validation status is done using the `taskId`. 

## How to test

-
-
-
