### PR TITLE
Verify contract if codeHash matches already verified contract

### DIFF
--- a/apps/api/src/endpoints/verifier/verifier.controller.ts
+++ b/apps/api/src/endpoints/verifier/verifier.controller.ts
@@ -6,6 +6,7 @@ import {
   VerifierCodeHashResponse,
   VerifierDeletion,
   VerifierDeletionResponse,
+  VerifierFromExisting,
 } from '@libs/common';
 import { TaskService, VerifierService } from '@libs/services';
 import { ParseBoolPipe, ParseIntPipe } from '@multiversx/sdk-nestjs-common';
@@ -28,6 +29,16 @@ export class VerifierController {
   })
   async verify(@Body() validateBody: Verifier): Promise<TaskIdResponse> {
     return await this.taskService.runVerifier(validateBody);
+  }
+
+  @Post('/from-existing')
+  @ApiResponse({
+    status: 200,
+    description: 'Queues a contract verification task from an existing verified contract and returns the task ID',
+    type: TaskIdResponse,
+  })
+  async verifyFromExisting(@Body() validateBody: VerifierFromExisting): Promise<TaskIdResponse> {
+    return await this.taskService.runVerifierFromExisting(validateBody);
   }
 
   @Get()
@@ -118,7 +129,7 @@ export class VerifierController {
   status: 200,
   description: 'Contract verifier successfully deleted',
   type: VerifierDeletionResponse,
-})
+  })
   async deleteVerifier(@Body() argument: VerifierDeletion): Promise<VerifierDeletionResponse> {
     const response = await this.verifierService.removeContractVerifierSource(argument);
     return new VerifierDeletionResponse({

--- a/apps/queue-worker/src/worker/queues/verifier.queue.service.ts
+++ b/apps/queue-worker/src/worker/queues/verifier.queue.service.ts
@@ -20,6 +20,12 @@ export class VerifierQueueService {
     return await this.worker.workVerifier(job.data.taskId, job.data.data.validate);
   }
 
+  @Process({ name: 'validateFromExisting', concurrency: 1 })
+  async onVerifyFromExistingRequest(job: Job<any>) {
+    this.logger.log({ type: 'consumer', jobId: job.id, identifier: job.data.data.validateFromExisting.contract, attemptsMade: job.attemptsMade });
+    return await this.worker.workVerifierFromExisting(job.data.taskId, job.data.data.validateFromExisting);
+  }
+
   @OnQueueError()
   handleError(error: Error) {
     this.logger.error('Queue error:', error.message);

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,8 +13,6 @@ libs:
       pinataUrl: ${PINATA_URL}
       pinataJwt: ${PINATA_JWT}
       fileStorageCdnUrl: ${FILE_STORAGE_CDN_URL}
-    queues:
-      api: ${API_QUEUE}
     network: ${NETWORK}
     urls:
       api: ${API_URL}

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -19,8 +19,6 @@ libs:
       enum: [devnet, testnet, mainnet]
     urls:
       api: string
-    queues:
-      api: string
     database:
       host: string
       port: integer

--- a/libs/common/src/dtos/index.ts
+++ b/libs/common/src/dtos/index.ts
@@ -8,6 +8,7 @@ export * from './verifier';
 export * from './verifier.deletion';
 export * from './verifier.deletion.payload';
 export * from './verifier.deletion.response';
+export * from './verifier.from.existing';
 export * from './verifier.hash.response';
 export * from './verifier.payload';
 export * from './verifier.response';

--- a/libs/common/src/dtos/verifier.from.existing.ts
+++ b/libs/common/src/dtos/verifier.from.existing.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty } from "class-validator";
+import { IsScAddress } from "../decorators";
+
+export class VerifierFromExisting {
+  constructor(partial?: Partial<VerifierFromExisting>) {
+    Object.assign(this, partial);
+  }
+
+  @ApiProperty({ description: 'Contract address to verify.', type: String, required: true })
+  @IsScAddress()
+  @IsNotEmpty()
+  contract: string = '';
+
+  @ApiProperty({ description: 'Existing verified contract address.', type: String, required: true })
+  @IsScAddress()
+  @IsNotEmpty()
+  existingVerifiedContract: string = '';
+}

--- a/libs/common/src/dtos/verifier.payload.ts
+++ b/libs/common/src/dtos/verifier.payload.ts
@@ -18,7 +18,7 @@ export class VerifierPayload {
   @IsNotEmpty()
   dockerImage: string = '';
 
-  @ApiProperty({ description: 'Source code.' })
+  @ApiProperty({ description: 'The packaged source code.' })
   @IsObject()
   @IsNotEmpty()
   sourceCode: any;

--- a/libs/common/src/dtos/verifier.ts
+++ b/libs/common/src/dtos/verifier.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { VerifierPayload } from './verifier.payload';
 
 export class Verifier {
@@ -8,12 +8,12 @@ export class Verifier {
     Object.assign(this, partial);
   }
 
-  @ApiProperty({ description: 'Payload signature', type: String })
+  @ApiProperty({ description: 'Payload signature (no longer required)', type: String, required: false })
   @IsString()
-  @IsNotEmpty()
-  signature: string = '';
+  @IsOptional()
+  signature?: string;
 
-  @ApiProperty({ description: 'Payload', type: VerifierPayload })
+  @ApiProperty({ description: 'Payload', type: VerifierPayload, required: true })
   @ValidateNested()
   @Type(() => VerifierPayload)
   @IsNotEmpty()

--- a/libs/common/src/entities/config.d.ts
+++ b/libs/common/src/entities/config.d.ts
@@ -25,9 +25,6 @@ export interface Config {
       urls: {
         api: string;
       };
-      queues: {
-        api: string;
-      };
       database: {
         host: string;
         port: number;

--- a/libs/common/src/pubsub/pub.sub.listener.controller.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.controller.ts
@@ -47,7 +47,6 @@ export class PubSubListenerController {
         contract: value.validateFromExisting.contract,
         environment }
     );
-    this.logger.log('Received validateFromExisting event', { taskId, type, value, environment });
     await this.workerService.addVerifierFromExistingJobIntoQueue(type, taskId, value);
   }
 }

--- a/libs/common/src/pubsub/pub.sub.listener.controller.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.controller.ts
@@ -47,6 +47,7 @@ export class PubSubListenerController {
         contract: value.validateFromExisting.contract,
         environment }
     );
+    this.logger.log('Received validateFromExisting event', { taskId, type, value, environment });
     await this.workerService.addVerifierFromExistingJobIntoQueue(type, taskId, value);
   }
 }

--- a/libs/common/src/pubsub/pub.sub.listener.controller.ts
+++ b/libs/common/src/pubsub/pub.sub.listener.controller.ts
@@ -14,17 +14,39 @@ export class PubSubListenerController {
 
   @EventPattern('validate')
   async validate({
-      taskId,
-      type,
-      value,
-      environment,
-    }: {
-      taskId: string;
-      type: string;
-      value: any;
-      environment: "devnet" | "testnet" | "mainnet";
-    }) {
-      this.logger.log('Received validate event', { taskId, type, contract: value.validate.payload.contract, environment });
-      await this.workerService.addJobIntoQueue(type, taskId, value);
-    }
+    taskId,
+    type,
+    value,
+    environment,
+  }: {
+    taskId: string;
+    type: string;
+    value: any;
+    environment: "devnet" | "testnet" | "mainnet";
+  }) {
+    this.logger.log('Received validate event', { taskId, type, contract: value.validate.payload.contract, environment });
+    await this.workerService.addVerifierJobIntoQueue(type, taskId, value);
+  }
+
+  @EventPattern('validateFromExisting')
+  async validateFromExisting({
+    taskId,
+    type,
+    value,
+    environment,
+  }: {
+    taskId: string;
+    type: string;
+    value: any;
+    environment: "devnet" | "testnet" | "mainnet";
+  }) {
+    this.logger.log(
+      'Received validateFromExisting event', {
+        taskId,
+        type,
+        contract: value.validateFromExisting.contract,
+        environment }
+    );
+    await this.workerService.addVerifierFromExistingJobIntoQueue(type, taskId, value);
+  }
 }

--- a/libs/common/src/queue-worker/worker.service.ts
+++ b/libs/common/src/queue-worker/worker.service.ts
@@ -1,7 +1,7 @@
 import { InjectQueue } from "@nestjs/bull";
 import { Injectable, Logger } from "@nestjs/common";
 import { Queue } from "bull";
-import { Verifier } from "../dtos";
+import { Verifier, VerifierFromExisting } from "../dtos";
 
 @Injectable()
 export class WorkerService {
@@ -13,11 +13,19 @@ export class WorkerService {
     this.logger = new Logger(WorkerService.name);
   }
 
-  async addJobIntoQueue(type: string, taskId: string, data: Verifier) {
+  async addVerifierJobIntoQueue(type: string, taskId: string, data: Verifier) {
     const job = await this.verifierQueue.add(type, {taskId, data}, {
         jobId: taskId,
         attempts: 1,
       });
     this.logger.log({ type: 'producer', jobId: job.id, identifier: job.data.data.validate.payload.contract });
+  }
+
+  async addVerifierFromExistingJobIntoQueue(type: string, taskId: string, data: VerifierFromExisting) {
+    const job = await this.verifierQueue.add(type, {taskId, data}, {
+        jobId: taskId,
+        attempts: 1,
+      });
+    this.logger.log({ type: 'producer', jobId: job.id, identifier: job.data.data.validateFromExisting.contract });
   }
 }

--- a/libs/database/src/repositories/contract.verifier.repository.ts
+++ b/libs/database/src/repositories/contract.verifier.repository.ts
@@ -36,7 +36,7 @@ export class ContractVerifierRepository {
       .exec();
   }
 
-  /* Find contracts that were verified but the bytecode has changed */
+  /** Find contracts that were verified but the bytecode has changed. */
   async findOutdated(
     projection?: Record<string, number>,
   ): Promise<Partial<ContractVerifier>[]> {

--- a/libs/services/src/task/task.service.ts
+++ b/libs/services/src/task/task.service.ts
@@ -4,6 +4,7 @@ import {
   TaskIdResponse,
   TaskStatus,
   Verifier,
+  VerifierFromExisting,
 } from '@libs/common';
 import { CacheService } from '@multiversx/sdk-nestjs-cache';
 import { Constants } from '@multiversx/sdk-nestjs-common';
@@ -40,22 +41,19 @@ export class TaskService {
       `Received verifier request for contract ${validate.payload.contract}`,
     );
 
-    let response: any;
-    try {
-      response = await this.apiService.get(
-        `${this.configService.config.urls.api}/accounts/${validate.payload.contract}`,
-      );
-    } catch (error: any) {
-      this.logger.error(`Error fetching account data for contract ${validate.payload.contract}, error: ${error.message}`);
-      throw new InternalServerErrorException(`Failed to fetch account data for contract ${validate.payload.contract}`);
-    }
-
-    const ownerAddress = response.data?.ownerAddress;
-    if (!ownerAddress) {
-      throw new BadRequestException('Could not determine owner address for the contract.');
-    }
-
+    await this.ensureContractExists(validate.payload.contract);
     return await this.run('validate', { validate });
+  }
+
+  async runVerifierFromExisting(validateFromExisting: VerifierFromExisting): Promise<TaskIdResponse> {
+    this.logger.log(
+      `Received verifier request for contract ${validateFromExisting.contract} from existing verified contract ${validateFromExisting.existingVerifiedContract}`,
+    );
+
+    await this.ensureContractExists(validateFromExisting.contract);
+    await this.ensureContractExists(validateFromExisting.existingVerifiedContract);
+
+    return await this.run('validateFromExisting', { validateFromExisting });
   }
 
   private async run(type: string, value: any): Promise<any> {
@@ -77,5 +75,23 @@ export class TaskService {
       Constants.oneHour(),
     );
     return taskId;
+  }
+
+  /** Ensure the contract is deployed by fetching the owner. */
+  private async ensureContractExists(address: string): Promise<void> {
+    let response: any;
+    try {
+      response = await this.apiService.get(
+        `${this.configService.config.urls.api}/accounts/${address}`,
+      );
+    } catch (error: any) {
+      this.logger.error(`Error fetching account data for contract ${address}, error: ${error.message}`);
+      throw new InternalServerErrorException(`Failed to fetch account data for contract ${address}`);
+    }
+
+    const ownerAddress = response.data?.ownerAddress;
+    if (!ownerAddress) {
+      throw new BadRequestException('Could not determine owner address for the contract.');
+    }
   }
 }

--- a/libs/services/src/task/task.service.ts
+++ b/libs/services/src/task/task.service.ts
@@ -56,14 +56,14 @@ export class TaskService {
     return await this.run('validateFromExisting', { validateFromExisting });
   }
 
-  private async run(type: string, value: any): Promise<any> {
+  private async run(type: string, value: any): Promise<TaskIdResponse> {
     const taskId = await this.runWork(type, value);
     return { taskId };
   }
 
   private async runWork(type: string, value: any): Promise<string> {
     const taskId = randomUUID();
-    this.clientProxy.emit(this.configService.config.queues.api, {
+    this.clientProxy.emit(type, {
       taskId,
       type,
       value,

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -480,8 +480,8 @@ export class VerifierService {
       `Verifier from existing process started for contract ${validateFromExisting.contract}`,
     );
 
-    const verfiedContract = await this.getContractVerifierModel(validateFromExisting.existingVerifiedContract);
-    if (!verfiedContract) {
+    const verifiedContract = await this.getContractVerifierModel(validateFromExisting.existingVerifiedContract);
+    if (!verifiedContract) {
       this.logger.log(`No verified contract found for address ${validateFromExisting.existingVerifiedContract}`);
       throw new NotFoundException(`Verified contract not found for address: ${validateFromExisting.existingVerifiedContract}`);
     }
@@ -489,7 +489,7 @@ export class VerifierService {
     const verifiedContractApiData = await this.getContractDataFromApi(validateFromExisting.existingVerifiedContract);
     const verifiedRemoteCodeHash = Buffer.from(verifiedContractApiData?.codeHash, 'base64').toString('hex');
 
-    if (verfiedContract.codeHash !== verifiedRemoteCodeHash) {
+    if (verifiedContract.codeHash !== verifiedRemoteCodeHash) {
       this.logger.log(`Bytecode changed for existing verified contract ${validateFromExisting.existingVerifiedContract}`);
       throw new BadRequestException('Bytecode changed for existing verified contract');
     }
@@ -497,19 +497,19 @@ export class VerifierService {
     const contractApiData = await this.getContractDataFromApi(validateFromExisting.contract);
     const contractRemoteCodeHash = Buffer.from(contractApiData?.codeHash, 'base64').toString('hex');
 
-    if (verfiedContract.codeHash !== contractRemoteCodeHash) {
+    if (verifiedContract.codeHash !== contractRemoteCodeHash) {
       this.logger.log(
-        `Source code hashes do not match - existing verified contract: ${verfiedContract.codeHash} - target contract: ${contractRemoteCodeHash}`,
+        `Source code hashes do not match - existing verified contract: ${verifiedContract.codeHash} - target contract: ${contractRemoteCodeHash}`,
       );
       throw new BadRequestException('Source code hash does not match verified contract');
     }
 
     await this.contractVerifierRepository.save(validateFromExisting.contract, {
-      source: verfiedContract.source,
-      codeHash: verfiedContract.codeHash,
-      ipfsFileHash: verfiedContract.ipfsFileHash,
+      source: verifiedContract.source,
+      codeHash: verifiedContract.codeHash,
+      ipfsFileHash: verifiedContract.ipfsFileHash,
       status: ContractVerifierStatus.success,
-      dockerImage: verfiedContract.dockerImage,
+      dockerImage: verifiedContract.dockerImage,
     });
     this.logger.log(
       `Contract verifier from existing saved to database - contract: ${validateFromExisting.contract} - from existing verified contract: ${validateFromExisting.existingVerifiedContract}`,
@@ -517,9 +517,9 @@ export class VerifierService {
 
     return new SuccessfulVerifierResponse({
       address: validateFromExisting.contract,
-      codeHash: verfiedContract.codeHash,
-      ipfsFileHash: verfiedContract.ipfsFileHash,
-      dockerImage: verfiedContract.dockerImage,
+      codeHash: verifiedContract.codeHash,
+      ipfsFileHash: verifiedContract.ipfsFileHash,
+      dockerImage: verifiedContract.dockerImage,
     });
   }
 

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -9,6 +9,7 @@ import {
   VerifierCodeHashResponse,
   VerifierDeletion,
   VerifierDeletionPayload,
+  VerifierFromExisting,
   VerifierPayload,
 } from '@libs/common';
 import { CommonConfigService } from '@libs/common/config/common.config.service';
@@ -472,6 +473,54 @@ export class VerifierService {
       temporaryFile.removeCallback();
       temporaryFolder.removeCallback();
     }
+  }
+
+  async validateFromExisting(validateFromExisting: VerifierFromExisting): Promise<SuccessfulVerifierResponse> {
+    this.logger.log(
+      `Verifier from existing process started for contract ${validateFromExisting.contract}`,
+    );
+
+    const verfiedContract = await this.getContractVerifierModel(validateFromExisting.existingVerifiedContract);
+    if (!verfiedContract) {
+      this.logger.log(`No verified contract found for address ${validateFromExisting.existingVerifiedContract}`);
+      throw new NotFoundException(`Verified contract not found for address: ${validateFromExisting.existingVerifiedContract}`);
+    }
+
+    const verifiedContractApiData = await this.getContractDataFromApi(validateFromExisting.existingVerifiedContract);
+    const verifiedRemoteCodeHash = Buffer.from(verifiedContractApiData?.codeHash, 'base64').toString('hex');
+
+    if (verfiedContract.codeHash !== verifiedRemoteCodeHash) {
+      this.logger.log(`Bytecode changed for existing verified contract ${validateFromExisting.existingVerifiedContract}`);
+      throw new BadRequestException('Bytecode changed for existing verified contract');
+    }
+
+    const contractApiData = await this.getContractDataFromApi(validateFromExisting.contract);
+    const contractRemoteCodeHash = Buffer.from(contractApiData?.codeHash, 'base64').toString('hex');
+
+    if (verfiedContract.codeHash !== contractRemoteCodeHash) {
+      this.logger.log(
+        `Source code hashes do not match - existing verified contract: ${verfiedContract.codeHash} - target contract: ${contractRemoteCodeHash}`,
+      );
+      throw new BadRequestException('Source code hash does not match verified contract');
+    }
+
+    await this.contractVerifierRepository.save(validateFromExisting.contract, {
+      source: verfiedContract.source,
+      codeHash: verfiedContract.codeHash,
+      ipfsFileHash: verfiedContract.ipfsFileHash,
+      status: ContractVerifierStatus.success,
+      dockerImage: verfiedContract.dockerImage,
+    });
+    this.logger.log(
+      `Contract verifier from existing saved to database - contract: ${validateFromExisting.contract} - from existing verified contract: ${validateFromExisting.existingVerifiedContract}`,
+    );
+
+    return new SuccessfulVerifierResponse({
+      address: validateFromExisting.contract,
+      codeHash: verfiedContract.codeHash,
+      ipfsFileHash: verfiedContract.ipfsFileHash,
+      dockerImage: verfiedContract.dockerImage,
+    });
   }
 
   private async getContractDataFromApi(address: string, shouldThrowError: boolean = true): Promise<any> {

--- a/libs/services/src/worker/worker.service.ts
+++ b/libs/services/src/worker/worker.service.ts
@@ -3,6 +3,7 @@ import {
   SuccessfulVerifierResponse,
   TaskStatus,
   Verifier,
+  VerifierFromExisting,
 } from '@libs/common';
 import {
   Injectable,
@@ -42,6 +43,32 @@ export class WorkerService {
 
       await this.updateTask(taskId, TaskStatus.error, errorResponse);
       console.error(`Error in workVerifier for task ${taskId}; error: ${error.message}, stack: ${error.stack}`);
+    }
+  }
+
+  async workVerifierFromExisting(taskId: string, validate: VerifierFromExisting): Promise<void> {
+    this.logger.log(`Task ${taskId} - Starting work`);
+
+    try {
+      await this.updateTask(taskId, TaskStatus.started);
+
+      const workResult = await this.verifierService.validateFromExisting(validate);
+
+      await this.updateTask(taskId, TaskStatus.finished, workResult);
+      this.logger.log(`Task ${taskId} - Work completed successfully`);
+    } catch (error: any) {
+      this.logger.error(`Task ${taskId} failed`);
+
+      const errorResponse = {
+        message: error.response?.message || error.message || 'An error occurred',
+        error: error.response?.error || 'Error',
+        statusCode: error.response?.statusCode || 500,
+      };
+
+      await this.updateTask(taskId, TaskStatus.error, errorResponse);
+      console.error(
+        `Error in workVerifierFromExisting for task ${taskId}; error: ${error.message}, stack: ${error.stack}`
+      );
     }
   }
 

--- a/libs/test/mocks/validate.from.existing.mock.ts
+++ b/libs/test/mocks/validate.from.existing.mock.ts
@@ -1,0 +1,4 @@
+export const validateFromExistingMock = {
+  contract: 'erd1qqqqqqqqqqqqqpgqxvqq8mdy20eq6u9t09sp2tqt0f6gpyr0d8ss0xgfqz',
+  existingVerifiedContract: 'erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q',
+ };

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -40,6 +40,7 @@ import { ContractVerifierRepository } from '../database/src';
 import { DockerRunner } from '../services/src/docker/docker.runner';
 import { PinataService } from '../services/src/pinata/pinata.service';
 import { VerifierService } from "../services/src/verifier";
+import { validateFromExistingMock } from './mocks/validate.from.existing.mock';
 import { validatePayloadMock } from './mocks/validate.payload.mock';
 import { dockerImage, mockAddress, mockCodeHash, pinataHash, verifiedContractMock } from './mocks/verified.contract.mock';
 import { verifiedContractInfoSourceMock } from './mocks/verified.source.mock';
@@ -403,5 +404,13 @@ describe('VerifierService', () => {
             ipfsFileHash: pinataHash,
             dockerImage: dockerImage,
         });
+    });
+
+    it('should validate from existing contract - existing not found', async () => {
+        contractVerifierRepository.findOne.mockResolvedValue(null);
+
+        await expect(service.validateFromExisting(validateFromExistingMock)).rejects.toThrow(
+            new NotFoundException('Verified contract not found for address: erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q')
+        );
     });
 });

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -413,4 +413,67 @@ describe('VerifierService', () => {
             new NotFoundException('Verified contract not found for address: erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q')
         );
     });
+
+    it('should validate from existing contract - codeHash changed for verified contract', async () => {
+        cacheService.getOrSet.mockImplementation((_key, callback) => {
+            return Promise.resolve(callback());
+        });
+        contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
+        apiService.get.mockResolvedValue({
+            data: {
+                codeHash: Buffer.from('0c51a67e88488825fc570e2bcb741f1f1e1d2c36b6f563980eda6f2a1b67c725', 'hex').toString('base64'),
+            },
+        });
+
+        await expect(service.validateFromExisting(validateFromExistingMock)).rejects.toThrow(
+            new BadRequestException('Bytecode changed for existing verified contract')
+        );
+    });
+
+    it('should validate from existing contract - codeHash does not match codeHash of verified contract', async () => {
+        cacheService.getOrSet.mockImplementation((_key, callback) => {
+            return Promise.resolve(callback());
+        });
+        contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                codeHash: Buffer.from(mockCodeHash, 'hex').toString('base64'),
+            },
+        });
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                codeHash: Buffer.from('0c51a67e88488825fc570e2bcb741f1f1e1d2c36b6f563980eda6f2a1b67c725', 'hex').toString('base64'),
+            },
+        });
+
+        await expect(service.validateFromExisting(validateFromExistingMock)).rejects.toThrow(
+            new BadRequestException('Source code hash does not match verified contract')
+        );
+    });
+
+    it('should validate from existing contract', async () => {
+        cacheService.getOrSet.mockImplementation((_key, callback) => {
+            return Promise.resolve(callback());
+        });
+        contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                codeHash: Buffer.from(mockCodeHash, 'hex').toString('base64'),
+            },
+        });
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                codeHash: Buffer.from(mockCodeHash, 'hex').toString('base64'),
+            },
+        });
+        contractVerifierRepository.save.mockResolvedValue();
+
+        const result = await service.validateFromExisting(validateFromExistingMock);
+        expect(result).toEqual({
+            address: validateFromExistingMock.contract,
+            codeHash: mockCodeHash,
+            ipfsFileHash: pinataHash,
+            dockerImage: dockerImage,
+        });
+    });
 });


### PR DESCRIPTION
## Type

- [ ] Bug
- [x] Feature
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting

Contract verification can be performed based on the codeHash of another contract. If we have a verified contract that has the exact codeHash as the contract we want to verify, we can safely perform the verification because only having the exact same source code gives us the same codeHash.

## Proposed Changes

A verification request can be made by calling the `/verifier/from-existing` endpoint and sending as the payload an object of type:
```json
{
  "contract": "erd1qqqqqq...",
  "existingVerifiedContract": "erd1qqqqqqq..."
}
```

If the codeHashes match, contract verification can be performed without having the source code and without running a docker image to build the contract. A new entry is created for the new contract with the info of the already verified contract.

## How to test

-
-
-
