### PR TITLE
Signature check improvements when deleting verified contract

### DIFF
--- a/apps/api/src/endpoints/verifier/verifier.controller.ts
+++ b/apps/api/src/endpoints/verifier/verifier.controller.ts
@@ -27,6 +27,10 @@ export class VerifierController {
     description: 'Queues a contract verification task and returns the task ID',
     type: TaskIdResponse,
   })
+  @ApiResponse({
+    status: 404,
+    description: 'Contract to be verified does not exist',
+  })
   async verify(@Body() validateBody: Verifier): Promise<TaskIdResponse> {
     return await this.taskService.runVerifier(validateBody);
   }
@@ -36,6 +40,10 @@ export class VerifierController {
     status: 200,
     description: 'Queues a contract verification task from an existing verified contract and returns the task ID',
     type: TaskIdResponse,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Could not find the contract to verify or the existing verified contract',
   })
   async verifyFromExisting(@Body() validateBody: VerifierFromExisting): Promise<TaskIdResponse> {
     return await this.taskService.runVerifierFromExisting(validateBody);
@@ -119,16 +127,22 @@ export class VerifierController {
   async getContractCodeHash(
     @Param('address', ParseScAddressPipe) address: string,
   ): Promise<VerifierCodeHashResponse> {
-    const data = await this.verifierService.getContractVerifierCodeHash(address);
-
-    return { codeHash: data.codeHash };
+    return await this.verifierService.getContractVerifierCodeHash(address);
   }
 
   @Delete()
   @ApiResponse({
   status: 200,
-  description: 'Contract verifier successfully deleted',
+  description: 'Verified contract successfully deleted',
   type: VerifierDeletionResponse,
+  })
+  @ApiResponse({
+  status: 400,
+  description: 'Could not determine the owner of the contract',
+  })
+  @ApiResponse({
+  status: 404,
+  description: 'Verified contract not found for the given address',
   })
   async deleteVerifier(@Body() argument: VerifierDeletion): Promise<VerifierDeletionResponse> {
     const response = await this.verifierService.removeContractVerifierSource(argument);

--- a/apps/api/src/endpoints/verifier/verifier.controller.ts
+++ b/apps/api/src/endpoints/verifier/verifier.controller.ts
@@ -28,8 +28,24 @@ export class VerifierController {
     type: TaskIdResponse,
   })
   @ApiResponse({
+    status: 400,
+    description: 'Invalid docker image',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Source code hash does not match deployed contract',
+  })
+  @ApiResponse({
     status: 404,
     description: 'Contract to be verified does not exist',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Contract build failed',
+  })
+  @ApiResponse({
+    status: 500,
+    description: 'Failed to upload contract to IPFS',
   })
   async verify(@Body() validateBody: Verifier): Promise<TaskIdResponse> {
     return await this.taskService.runVerifier(validateBody);
@@ -40,6 +56,14 @@ export class VerifierController {
     status: 200,
     description: 'Queues a contract verification task from an existing verified contract and returns the task ID',
     type: TaskIdResponse,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bytecode changed for existing verified contract',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Source code hash does not match verified contract',
   })
   @ApiResponse({
     status: 404,
@@ -138,15 +162,19 @@ export class VerifierController {
   })
   @ApiResponse({
   status: 400,
-  description: 'Could not determine the owner of the contract',
+  description: 'Could not determine owner address for the contract',
   })
   @ApiResponse({
   status: 401,
-  description: "Unauthorized. Possible reasons: invalid signature or owner of the contract is a smart contract (deletion not allowed).",
+  description: "Unauthorized. Possible reasons: invalid signature or owner of the contract is a smart contract (deletion not allowed)",
   })
   @ApiResponse({
   status: 404,
   description: 'Verified contract not found for the given address',
+  })
+  @ApiResponse({
+  status: 500,
+  description: 'Failed to delete verified contract',
   })
   async deleteVerifier(@Body() argument: VerifierDeletion): Promise<VerifierDeletionResponse> {
     const response = await this.verifierService.removeContractVerifierSource(argument);

--- a/apps/api/src/endpoints/verifier/verifier.controller.ts
+++ b/apps/api/src/endpoints/verifier/verifier.controller.ts
@@ -141,6 +141,10 @@ export class VerifierController {
   description: 'Could not determine the owner of the contract',
   })
   @ApiResponse({
+  status: 401,
+  description: "Unauthorized. Possible reasons: invalid signature or owner of the contract is a smart contract (deletion not allowed).",
+  })
+  @ApiResponse({
   status: 404,
   description: 'Verified contract not found for the given address',
   })

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -320,7 +320,7 @@ export class VerifierService {
     if (!ownerAddress) {
       this.logger.error(`No owner address for contract ${address}`);
       throw new BadRequestException(
-        'Could not determine owner address for the owner contract.',
+        'Could not determine owner address for the contract.',
       );
     }
 

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -310,14 +310,17 @@ export class VerifierService {
     return result;
   }
 
-  /** Fetches the owner of the owner contract. If the owner is a smart contract, deletion is not allowed. */
+  /**
+   * Fetches the owner of the contract owner (when the contract owner is itself a smart contract).
+   * If the owner of the contract owner is a smart contract, deletion is not allowed.
+   */
   private async getOwnerOfOwnerContract(address: string): Promise<string> {
     const response = await this.getContractDataFromApi(address);
     const ownerAddress = response?.ownerAddress;
     if (!ownerAddress) {
       this.logger.error(`No owner address for contract ${address}`);
       throw new BadRequestException(
-        'Could not determine owner address for the contract.',
+        'Could not determine owner address for the owner contract.',
       );
     }
 

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -275,12 +275,16 @@ export class VerifierService {
 
   public async removeContractVerifierSource(body: VerifierDeletion): Promise<ContractVerifierModel> {
     const apiResponse = await this.getContractDataFromApi(body.payload.contract);
-    const ownerAddress = apiResponse?.ownerAddress;
+    let ownerAddress: string | undefined = apiResponse?.ownerAddress;
     if (!ownerAddress) {
       this.logger.error(`No owner address for contract ${body.payload.contract}`);
       throw new BadRequestException(
         'Could not determine owner address for the contract.',
       );
+    }
+
+    if (Address.newFromBech32(ownerAddress).isSmartContract()) {
+      ownerAddress = await this.getOwnerOfOwnerContract(ownerAddress);
     }
 
     if (!this.checkPayloadSignature(body.signature, body.payload, ownerAddress)) {
@@ -304,6 +308,26 @@ export class VerifierService {
     }
 
     return result;
+  }
+
+  /** Fetches the owner of the owner contract. If the owner is a smart contract, deletion is not allowed. */
+  private async getOwnerOfOwnerContract(address: string): Promise<string> {
+    const response = await this.getContractDataFromApi(address);
+    const ownerAddress = response?.ownerAddress;
+    if (!ownerAddress) {
+      this.logger.error(`No owner address for contract ${address}`);
+      throw new BadRequestException(
+        'Could not determine owner address for the contract.',
+      );
+    }
+
+    if (Address.newFromBech32(ownerAddress).isSmartContract()) {
+      throw new UnauthorizedException(
+        'Owner of the contract is a smart contract. Deletion not allowed.',
+      );
+    }
+
+    return ownerAddress;
   }
 
   private async deleteContractVerifier(

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -260,7 +260,7 @@ describe('VerifierService', () => {
         };
 
         await expect(service.removeContractVerifierSource(requestBody)).rejects.toThrow(
-            new BadRequestException('Could not determine owner address for the owner contract.')
+            new BadRequestException('Could not determine owner address for the contract.')
         );
     });
 

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -240,6 +240,56 @@ describe('VerifierService', () => {
         );
     });
 
+    it('should throw could not determine owner address for owner contract - delete contract verifier', async () => {
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgqxvqq8mdy20eq6u9t09sp2tqt0f6gpyr0d8ss0xgfqz',
+            },
+        });
+
+        apiService.get.mockResolvedValueOnce({
+            data: {},
+        });
+
+        const requestBody = {
+            'signature': '9cf0bfecf402a73c37733e78780bd4ddd3fec7f97831faf91b173a7715ce5822053ac20329fc004272d22e284a10da6f057df5a7783b11cfda1c90163d66b60f',
+            'payload': {
+                'contract': 'erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q',
+                'codeHash': '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+            },
+        };
+
+        await expect(service.removeContractVerifierSource(requestBody)).rejects.toThrow(
+            new BadRequestException('Could not determine owner address for the owner contract.')
+        );
+    });
+
+    it('should throw owner of owner contract is smart contract - delete contract verifier', async () => {
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgqxvqq8mdy20eq6u9t09sp2tqt0f6gpyr0d8ss0xgfqz',
+            },
+        });
+
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgqnsfdqlxg7c2nhf3hpqx53qj8uu5jre6dd8ssffmvcd',
+            },
+        });
+
+        const requestBody = {
+            'signature': '9cf0bfecf402a73c37733e78780bd4ddd3fec7f97831faf91b173a7715ce5822053ac20329fc004272d22e284a10da6f057df5a7783b11cfda1c90163d66b60f',
+            'payload': {
+                'contract': 'erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q',
+                'codeHash': '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+            },
+        };
+
+        await expect(service.removeContractVerifierSource(requestBody)).rejects.toThrow(
+            new BadRequestException('Owner of the contract is a smart contract. Deletion not allowed.')
+        );
+    });
+
     it('should return invalid signature - delete contract verifier', async () => {
         apiService.get.mockResolvedValue({
             data: {

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -267,7 +267,7 @@ describe('VerifierService', () => {
 
         apiService.get.mockResolvedValue({
             data: {
-                ownerAddress: 'erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zp6hypefsdd8ssycr6th',
+                ownerAddress: 'erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th',
             },
         });
 
@@ -286,6 +286,78 @@ describe('VerifierService', () => {
         spy.mockRestore();
     });
 
+    it('should throw error if owner is SC and owner of owner is SC - delete contract verifier', async () => {
+        contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
+
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgq9ph6uhdl2hkq7sarxxwycr6txnx0ewcal3ts0cs79w',
+            },
+        });
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgqq75vtleur5rg74nk4f88ql6a7ajas073l3tsc5ljc9',
+            },
+        });
+
+        const requestBody = {
+            'signature': 'd0d16d94bb8c3b391c69d370fd3ca1e1fbf757f68ce543c1ed4ab7fe3c1208731b797342a76aea94b9cabc39ceb4afb7ac5b7e35475c44f52bfd938f1a5c8b0d',
+            'payload': {
+                'contract': 'erd1qqqqqqqqqqqqqpgq8uzcu905yt6xk7k6eg9gnhhxp6gk9swnd8sspla0v4',
+                'codeHash': '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+            },
+        };
+
+        await expect(service.removeContractVerifierSource(requestBody)).rejects.toThrow(
+            new UnauthorizedException('Owner of the contract is a smart contract. Deletion not allowed.')
+        );
+    });
+
+    it('should delete contract verifier - owner of owner contract', async () => {
+        const spy = jest.spyOn(service as any, 'checkPayloadSignature').mockImplementation(() => true);
+
+        cacheService.getOrSet.mockImplementation((_key, callback) => {
+            return Promise.resolve(callback());
+        });
+
+        contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
+        contractVerifierRepository.delete.mockResolvedValue(verifiedContractMock);
+
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qqqqqqqqqqqqqpgq9ph6uhdl2hkq7sarxxwycr6txnx0ewcal3ts0cs79w',
+            },
+        });
+        apiService.get.mockResolvedValueOnce({
+            data: {
+                ownerAddress: 'erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th',
+            },
+        });
+
+        const requestBody = {
+            'signature': '9cf0bfecf402a73c37733e78780bd4ddd3fec7f97831faf91b173a7715ce5822053ac20329fc004272d22e284a10da6f057df5a7783b11cfda1c90163d66b60f',
+            'payload': {
+                'contract': 'erd1qqqqqqqqqqqqqpgqvxzjqasv3jsu5kxtk8ergnqdhuk3vfmnd8ss3hzc3q',
+                'codeHash': '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+            },
+        };
+
+        const result = await service.removeContractVerifierSource(requestBody);
+        expect(result).toEqual({
+            address: mockAddress,
+            codeHash: '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+            source: {
+                abi: verifiedContractMock.source.abi,
+                contract: verifiedContractMock.source.contract,
+            },
+            status: 'success',
+            ipfsFileHash: 'QmR52Y13ZQbjnETjHsG6hLA7fgidyrWt1JVQDp6Ti1aD7N',
+            dockerImage: 'multiversx/sdk-rust-contract-builder:v10.0.0',
+        });
+
+        spy.mockRestore();
+    });
+
     it('should delete contract verifier', async () => {
         const spy = jest.spyOn(service as any, 'checkPayloadSignature').mockImplementation(() => true);
 
@@ -298,7 +370,7 @@ describe('VerifierService', () => {
 
         apiService.get.mockResolvedValue({
             data: {
-                ownerAddress: 'erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zp6hypefsdd8ssycr6th',
+                ownerAddress: 'erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th',
             },
         });
 


### PR DESCRIPTION
## Type

- [ ] Bug
- [x] Feature
- [ ] Refactoring
- [x] Performance improvement

## Problem setting

If the owner of the verified contract is also a smart contract, the deletion would have not been possible because smart contracts can't sign any payload/message.

## Proposed Changes

When receiving a deletion request, we check the owner of the contract. If the owner of the contract is also a smart contract, we check the "owner of the owner". If that is a regular address, we check if the payload has been signed with that address. In case the "owner of the owner" is still a smart contract, deletion is not possible, but that is a pretty rare scenario. 

## How to test

-
-
-
