### PR TITLE
Validate from existing improvement

### DIFF
--- a/apps/api/src/private.app.module.ts
+++ b/apps/api/src/private.app.module.ts
@@ -1,4 +1,9 @@
-import { ApiMetricsController, ApiMetricsModule, DynamicModuleUtils, HealthCheckController } from '@libs/common';
+import {
+  ApiMetricsController,
+  ApiMetricsModule,
+  DynamicModuleUtils,
+  HealthCheckController,
+} from '@libs/common';
 import { CommonConfigModule } from '@libs/common/config/common.config.module';
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { Module } from '@nestjs/common';
@@ -12,9 +17,7 @@ import { AppConfigModule } from './config/app-config.module';
     CommonConfigModule,
     AppConfigModule,
   ],
-  providers: [
-    DynamicModuleUtils.getNestJsApiConfigService(),
-  ],
+  providers: [DynamicModuleUtils.getNestJsApiConfigService()],
   controllers: [ApiMetricsController, HealthCheckController],
 })
 export class PrivateAppModule {}

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -533,13 +533,12 @@ export class VerifierService {
     const contract = await this.getContractVerifierModel(validateFromExisting.contract);
     if (contract) {
       const apiData = await this.getContractDataFromApi(validateFromExisting.contract);
-      const remoteCodeHash = Buffer.from(
-        apiData?.codeHash,
-        'base64',
-      ).toString('hex');
+      const remoteCodeHash = Buffer.from(apiData?.codeHash, 'base64').toString('hex');
 
       if (contract.codeHash === remoteCodeHash) {
-        this.logger.log(`Contract ${contract.address} already verified and codeHash did not change`);
+        this.logger.log(
+          `Contract ${contract.address} already verified and codeHash did not change`,
+        );
         return new SuccessfulVerifierResponse({
           address: contract.address,
           codeHash: contract.codeHash,

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -530,6 +530,25 @@ export class VerifierService {
       `Verifier from existing process started for contract ${validateFromExisting.contract}`,
     );
 
+    const contract = await this.getContractVerifierModel(validateFromExisting.contract);
+    if (contract) {
+      const apiData = await this.getContractDataFromApi(validateFromExisting.contract);
+      const remoteCodeHash = Buffer.from(
+        apiData?.codeHash,
+        'base64',
+      ).toString('hex');
+
+      if (contract.codeHash === remoteCodeHash) {
+        this.logger.log(`Contract ${contract.address} already verified and codeHash did not change`);
+        return new SuccessfulVerifierResponse({
+          address: contract.address,
+          codeHash: contract.codeHash,
+          ipfsFileHash: contract.ipfsFileHash,
+          dockerImage: contract.dockerImage,
+        });
+      }
+    }
+
     const verifiedContract = await this.getContractVerifierModel(
       validateFromExisting.existingVerifiedContract,
     );

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -644,6 +644,37 @@ describe('VerifierService', () => {
     });
   });
 
+  it('should validate from existing contract - existing already verified', async () => {
+    cacheService.getOrSet.mockImplementation((_key, callback) => {
+      return Promise.resolve(callback());
+    });
+
+    const contract = {
+      ...verifiedContractMock,
+      address: validateFromExistingMock.contract,
+    };
+    contractVerifierRepository.findOne.mockResolvedValue(contract);
+
+    apiService.get.mockResolvedValue({
+      data: {
+        codeHash: Buffer.from(
+          '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+          'hex',
+        ).toString('base64'),
+      },
+    });
+
+    contractVerifierRepository.save.mockResolvedValue();
+
+    const result = await service.validateFromExisting(validateFromExistingMock);
+    expect(result).toEqual({
+      address: validateFromExistingMock.contract,
+      codeHash: mockCodeHash,
+      ipfsFileHash: pinataHash,
+      dockerImage: dockerImage,
+    });
+  });
+
   it('should validate from existing contract - existing not found', async () => {
     contractVerifierRepository.findOne.mockResolvedValue(null);
 
@@ -677,6 +708,7 @@ describe('VerifierService', () => {
     cacheService.getOrSet.mockImplementation((_key, callback) => {
       return Promise.resolve(callback());
     });
+    contractVerifierRepository.findOne.mockResolvedValueOnce(null);
     contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
     apiService.get.mockResolvedValueOnce({
       data: {
@@ -701,17 +733,16 @@ describe('VerifierService', () => {
     cacheService.getOrSet.mockImplementation((_key, callback) => {
       return Promise.resolve(callback());
     });
+
+    contractVerifierRepository.findOne.mockResolvedValueOnce(null);
     contractVerifierRepository.findOne.mockResolvedValue(verifiedContractMock);
-    apiService.get.mockResolvedValueOnce({
+
+    apiService.get.mockResolvedValue({
       data: {
         codeHash: Buffer.from(mockCodeHash, 'hex').toString('base64'),
       },
     });
-    apiService.get.mockResolvedValueOnce({
-      data: {
-        codeHash: Buffer.from(mockCodeHash, 'hex').toString('base64'),
-      },
-    });
+
     contractVerifierRepository.save.mockResolvedValue();
 
     const result = await service.validateFromExisting(validateFromExistingMock);

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -664,8 +664,6 @@ describe('VerifierService', () => {
       },
     });
 
-    contractVerifierRepository.save.mockResolvedValue();
-
     const result = await service.validateFromExisting(validateFromExistingMock);
     expect(result).toEqual({
       address: validateFromExistingMock.contract,
@@ -684,7 +682,9 @@ describe('VerifierService', () => {
       ...verifiedContractMock,
       address: validateFromExistingMock.contract,
     };
-    contractVerifierRepository.findOne.mockResolvedValue(contract);
+    contractVerifierRepository.findOne.mockResolvedValueOnce(contract);
+    contractVerifierRepository.findOne.mockResolvedValueOnce(verifiedContractMock);
+
 
     apiService.get.mockResolvedValueOnce({
       data: {

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -675,6 +675,46 @@ describe('VerifierService', () => {
     });
   });
 
+  it('should validate from existing contract - existing already verified, bytecode changed', async () => {
+    cacheService.getOrSet.mockImplementation((_key, callback) => {
+      return Promise.resolve(callback());
+    });
+
+    const contract = {
+      ...verifiedContractMock,
+      address: validateFromExistingMock.contract,
+    };
+    contractVerifierRepository.findOne.mockResolvedValue(contract);
+
+    apiService.get.mockResolvedValueOnce({
+      data: {
+        codeHash: Buffer.from(
+          '0c51a67e88488825fc570e2bcb741f1f1e1d2c36b6f563980eda6f2a1b67c725',
+          'hex',
+        ).toString('base64'),
+      },
+    });
+
+    apiService.get.mockResolvedValue({
+      data: {
+        codeHash: Buffer.from(
+          '7f7376f37a9f809a1a9b21b60a2a9afe7c9d22ab65807324f537ab3696110a58',
+          'hex',
+        ).toString('base64'),
+      },
+    });
+
+    contractVerifierRepository.save.mockResolvedValue();
+
+    const result = await service.validateFromExisting(validateFromExistingMock);
+    expect(result).toEqual({
+      address: validateFromExistingMock.contract,
+      codeHash: mockCodeHash,
+      ipfsFileHash: pinataHash,
+      dockerImage: dockerImage,
+    });
+  });
+
   it('should validate from existing contract - existing not found', async () => {
     contractVerifierRepository.findOne.mockResolvedValue(null);
 


### PR DESCRIPTION
## Type

- [ ] Bug
- [ ] Feature
- [ ] Refactoring
- [x] Performance improvement

## Problem setting

In case an already verified contract was requested to be verified, there was no check for the contract to ensure it is not already verified.

## Proposed Changes

When a request is received, we check if the contract is already verified and in case it is, we check if the bytecode has changed. If it hasn't, the verified contract is returned, else, the verification performs as usual.

## How to test

-
-
-
