### PR TITLE
Fixes for removing contract

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -16,6 +16,7 @@ libs:
     network: ${NETWORK}
     urls:
       api: ${API_URL}
+      gateway: ${GATEWAY_URL}
     database:
       host: 'localhost'
       port: 27017

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -314,7 +314,7 @@ export class VerifierService {
     const contractAddress = body.payload.contract;
     let result: ContractVerifierModel | undefined;
 
-    this.cacheService.delete(CacheInfo.VerifiedContractModel(contractAddress).key);
+    await this.cacheService.delete(CacheInfo.VerifiedContractModel(contractAddress).key);
 
     try {
       result = await this.deleteContractVerifier(contractAddress);

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -307,7 +307,7 @@ export class VerifierService {
       ownerAddress = await this.getOwnerOfOwnerContract(ownerAddress);
     }
 
-    if (! await this.checkPayloadSignature(body.signature, body.payload, ownerAddress)) {
+    if (!(await this.checkPayloadSignature(body.signature, body.payload, ownerAddress))) {
       throw new UnauthorizedException('Invalid signature');
     }
 
@@ -389,7 +389,10 @@ export class VerifierService {
     const messageComputer = new MessageComputer();
     const verifyBytes = messageComputer.computeBytesForVerifying(signableMessage);
 
-    const secondVerificationResult = await verifier.verify(verifyBytes, signatureAsBuffer);
+    const secondVerificationResult = await verifier.verify(
+      verifyBytes,
+      signatureAsBuffer,
+    );
 
     return firstVerificationResult || secondVerificationResult;
   }

--- a/libs/services/src/verifier/verifier.service.ts
+++ b/libs/services/src/verifier/verifier.service.ts
@@ -314,6 +314,8 @@ export class VerifierService {
     const contractAddress = body.payload.contract;
     let result: ContractVerifierModel | undefined;
 
+    this.cacheService.delete(CacheInfo.VerifiedContractModel(contractAddress).key);
+
     try {
       result = await this.deleteContractVerifier(contractAddress);
     } catch (error) {
@@ -358,7 +360,7 @@ export class VerifierService {
   private async deleteContractVerifier(
     address: string,
   ): Promise<ContractVerifierModel | undefined> {
-    const verifier = await this.getContractVerifierModel(address);
+    const verifier = await this.getContractVerifierModelFromDb(address);
     if (!verifier) {
       return undefined;
     }

--- a/libs/test/verifier.service.spec.ts
+++ b/libs/test/verifier.service.spec.ts
@@ -121,6 +121,7 @@ describe('VerifierService', () => {
 
     cacheService = {
       getOrSet: jest.fn(),
+      delete: jest.fn(),
     } as any;
 
     const module: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
## Type

- [ ] Bug
- [ ] Feature
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting

If the contract was cached the response would look like it was deleted every time the deletion request was received, even though it was deleted.

## Proposed Changes

Remove the cache key, and read contract from db.

## How to test

-
-
-
